### PR TITLE
Viprinet customer router management domains

### DIFF
--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11301,7 +11301,6 @@ inc.hk
 // Submitted by Simon Kissel <hostmaster@viprinet.com> 2016-04-16
 router.management
 
-
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com> 2014-07-09
 yolasite.com

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11298,7 +11298,7 @@ ltd.hk
 inc.hk
 
 // Viprinet Europe GmbH : http://www.viprinet.com
-// Submitted by Simon Kissel <hostmaster@viprinet.com> 2016-04-16
+// Submitted by Simon Kissel <hostmaster@viprinet.com>
 router.management
 
 // Yola : https://www.yola.com/

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11298,8 +11298,9 @@ ltd.hk
 inc.hk
 
 // Viprinet Europe GmbH : http://www.viprinet.com
+// Submitted by Simon Kissel <hostmaster@viprinet.com> 2016-04-16
 router.management
-vipri.net
+
 
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com> 2014-07-09

--- a/public_suffix_list.dat
+++ b/public_suffix_list.dat
@@ -11297,6 +11297,10 @@ hk.org
 ltd.hk
 inc.hk
 
+// Viprinet Europe GmbH : http://www.viprinet.com
+router.management
+vipri.net
+
 // Yola : https://www.yola.com/
 // Submitted by Stefano Rivera <stefano@yola.com> 2014-07-09
 yolasite.com


### PR DESCRIPTION
Viprinet is a manufacturer of VPN Routers. SERIALNUMBER.router.management (.management is a new public TLD) are used to access our routers. In future, we also wish to support Let's encrypt, which requires this domain to be on the public suffix list so individual certificates can be requested per router. Subdomains of the vipri.net domain are internally used for update servers and the likes, and therefore also should be on the public suffic list.
